### PR TITLE
fix: handle nested directory strucutres within CBZs

### DIFF
--- a/manga_split.py
+++ b/manga_split.py
@@ -35,8 +35,7 @@ async def split_manga(manga, manga_dir, cbz: bool, chapter_re):
     await asyncio.to_thread(extract_zip, zip_path, extract_dir)
     
     # Process files and folders
-    directory_list = await asyncio.to_thread(lambda: [os.path.join(extract_dir, x) for x in os.listdir(extract_dir)])
-    files, _ = await asyncio.to_thread(folders_split, directory_list)
+    files, _ = await asyncio.to_thread(folders_split, extract_dir)
     
     # Organize chapters in a thread
     new_chapters = await organise_chapters(files, extract_dir, chapter_re)
@@ -61,8 +60,11 @@ def folders_split(directory):
     """Synchronously split into files and folders."""
     files = []
     folders = []
-    for item in directory:
-        (folders if os.path.isdir(item) else files).append(item)
+    for dirpath, dirnames, filenames in os.walk(directory):
+        for dirname in dirnames:
+            folders.append(os.path.join(dirpath, dirname))
+        for filename in filenames:
+            files.append(os.path.join(dirpath, filename))
     return files, folders
 
 async def organise_chapters(files, extract_dir, chapter_re):


### PR DESCRIPTION
I have a cbz that has a single folder within the archive that contains all the volume images. Maybe something changed with [ZipFile.extractall](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extractall) at some point, but when I run MangaSplitter on it now with python3.13, it creates that single folder within the `extract_dir` that MangaSplitter doesn't expect, so no files actually got processed. 

This change uses [os.walk](https://docs.python.org/3/library/os.html#os.walk) directly to get all the files out of the extract dir recursively.

It takes kind of a long amount of time to process, now (5.88 seconds on 3 volumes in my testing, when I'd expect it to be even quicker than that), so there might be some threading work that can be done here. Let me know if you want me to explore that for this PR.