### PR TITLE
use relpath between file and extract_dir to search regex

### DIFF
--- a/manga_split.py
+++ b/manga_split.py
@@ -71,7 +71,7 @@ async def organise_chapters(files, extract_dir, chapter_re):
     """Organize chapters using threads for I/O."""
     chapters = {}
     for page in files:
-        match = chapter_re.search(os.path.basename(page))
+        match = chapter_re.search(os.path.relpath(page, extract_dir))
         if not match:
             print(f'No chapter found in {page}')
             continue


### PR DESCRIPTION
allows for searching for the chapter pattern in any part of the path, including arbitrary directories within the cbz

for example, if the cbz contains a folder for each chapter
```
001/01.jpg
001/02.jpg
...
002/01.jpg
002/02.jpg
```
this change will allow for matching the chapter regex on `001` or `002`